### PR TITLE
Resubmit changes from https://github.com/ESUG/esug.github.io/pull/17

### DIFF
--- a/2018-Conference/talks/2018-Kubelka-LiveDocuments.pillar
+++ b/2018-Conference/talks/2018-Kubelka-LiveDocuments.pillar
@@ -1,8 +1,8 @@
 ! Manipulating live documents with Documenter
 
-Juraj Kubelka (alex.syrel@gmail.com)
+Juraj Kubelka (juraj.kubelka@icloud.com)
 
 ""Abstract:"" Documenter is the Glamorous Toolkit tool for creating and consuming live documents directly in the development environment. This session shows concrete examples of how it can support multiple scenarios: code documentation, tutorials, and interactive data notebook.
 
 ""Bio:"" 
-Needed
+Juraj Kubelka is a PhD student at the University of Chile and software developer at feenk.com. He earned his Master of Electrical Engineering and Informatics in Computer Science, June 2004 from the Czech Technical University in Prague. His interests lie in creating gratifying environments for all people involved in software development.


### PR DESCRIPTION
I do not know what happened with previous changes (https://github.com/ESUG/esug.github.io/pull/17).

I noticed that [calendar information](https://esug.github.io/2018-Conference/conf2018.html) is not up-to-date for my talk (Friday 11:30).