### PR TITLE
Update about_us.pillar: Mastodon and BlueSky

### DIFF
--- a/about_us.pillar
+++ b/about_us.pillar
@@ -56,7 +56,8 @@ For mailings to members and everybody who subscribed directly to the mailing lis
 
 !! ESUG on Social Media
 
-- Twitter: *https://x.com/esugsmalltalk*
+- Mastodon: *@esugsmalltalk*mastodon.social>https://mastodon.social/@esugsmalltalk*
+- BlueSky: *esugsmalltalk.bsky.social>https://bsky.app/profile/esugsmalltalk.bsky.social*
 - Page on *Facebook>https://www.facebook.com/profile.php?id=61565428452512*
 - Page on *LinkedIn>https://www.linkedin.com/company/104963294*
 


### PR DESCRIPTION
add links to the new accounts