### PR TITLE
Add SageTea Runtime ESUG 2026 talk proposal

### DIFF
--- a/2026-Conference/talks/sageTea-pharo-runtime-ai.pillar
+++ b/2026-Conference/talks/sageTea-pharo-runtime-ai.pillar
@@ -1,0 +1,53 @@
+!From Squeak to Pharo: Modernizing the Eclipse SageTea Runtime for Edge AI and Sovereign Computing
+
+= Authors
+* David Long
+* Stéphane Ducasse
+
+= Abstract
+
+The Eclipse SageTea Runtime project represents the modernization of a long-running Smalltalk-based runtime environment originally developed in Squeak and now actively migrated to Pharo. This talk presents both the technical challenges and architectural opportunities encountered during this transition.
+
+We discuss the historical architecture of SageTea and the motivations for migrating toward the modern Pharo ecosystem, including improved tooling, maintainability, packaging infrastructure, and deployment capabilities. Particular attention is given to compatibility issues encountered during the porting process, strategies for preserving image portability and legacy behavior, and the modernization of package management using Metacello baselines.
+
+The presentation also covers the integration of GitLab-based CI/CD pipelines, automated runtime provisioning, and deployment considerations for Pharo 13 in Linux environments. We will demonstrate the Eclipse SageTea Runtime packaging approach, including systemd deployment patterns, containerized runtime configurations, and reproducible runtime provisioning workflows.
+
+Beyond runtime engineering, we explore the relevance of classical AI systems implemented in Smalltalk and how these systems can complement modern LLM-based architectures through deterministic orchestration, explainability, low-memory execution, and strong runtime introspection. The talk concludes with a discussion of opportunities for Smalltalk systems in edge AI, secure communications infrastructure, and sovereign computing platforms.
+
+= Keywords
+
+Smalltalk, Pharo, Squeak, Classical AI, Eclipse Foundation, Low-Code, Edge Computing, Runtime Systems, Metacello, DevOps
+
+= Audience
+
+This talk is intended for:
+
+* Smalltalk developers interested in Pharo migration strategies
+* Runtime and VM developers
+* Researchers exploring explainable or deterministic AI systems
+* Developers interested in edge computing and low-resource AI runtimes
+* Members of the broader open source Smalltalk ecosystem
+
+= Speaker Biography
+
+== David Long
+
+David Long is the founder of SageTea Software and XFone Technologies. He has worked on Smalltalk-based enterprise systems, runtime environments, AI tooling, and secure mobile computing platforms for more than two decades. His recent work focuses on edge AI systems, secure communications infrastructure, and the modernization of the SageTea Runtime under the Eclipse Foundation.
+
+== Stéphane Ducasse
+
+Stéphane Ducasse is a leading contributor to the Pharo ecosystem, co-founder of the Pharo Consortium, and a long-time advocate for open source Smalltalk systems. He has authored numerous books and research papers on software engineering, reflective systems, and programming language design, and recently became a committer on the Eclipse SageTea Runtime project.
+
+= Duration
+
+30–45 minutes
+
+= Type
+
+Technical Presentation / Experience Report
+
+= Links
+
+* Eclipse SageTea Runtime Project
+* Pharo Smalltalk
+* ESUG Conference Series

--- a/sageTea-pharo-runtime-ai.pillar
+++ b/sageTea-pharo-runtime-ai.pillar
@@ -1,0 +1,53 @@
+!From Squeak to Pharo: Modernizing the Eclipse SageTea Runtime for Edge AI and Sovereign Computing
+
+= Authors
+* David Long
+* Stéphane Ducasse
+
+= Abstract
+
+The Eclipse SageTea Runtime project represents the modernization of a long-running Smalltalk-based runtime environment originally developed in Squeak and now actively migrated to Pharo. This talk presents both the technical challenges and architectural opportunities encountered during this transition.
+
+We discuss the historical architecture of SageTea and the motivations for migrating toward the modern Pharo ecosystem, including improved tooling, maintainability, packaging infrastructure, and deployment capabilities. Particular attention is given to compatibility issues encountered during the porting process, strategies for preserving image portability and legacy behavior, and the modernization of package management using Metacello baselines.
+
+The presentation also covers the integration of GitLab-based CI/CD pipelines, automated runtime provisioning, and deployment considerations for Pharo 13 in Linux environments. We will demonstrate the Eclipse SageTea Runtime packaging approach, including systemd deployment patterns, containerized runtime configurations, and reproducible runtime provisioning workflows.
+
+Beyond runtime engineering, we explore the relevance of classical AI systems implemented in Smalltalk and how these systems can complement modern LLM-based architectures through deterministic orchestration, explainability, low-memory execution, and strong runtime introspection. The talk concludes with a discussion of opportunities for Smalltalk systems in edge AI, secure communications infrastructure, and sovereign computing platforms.
+
+= Keywords
+
+Smalltalk, Pharo, Squeak, Classical AI, Eclipse Foundation, Low-Code, Edge Computing, Runtime Systems, Metacello, DevOps
+
+= Audience
+
+This talk is intended for:
+
+* Smalltalk developers interested in Pharo migration strategies
+* Runtime and VM developers
+* Researchers exploring explainable or deterministic AI systems
+* Developers interested in edge computing and low-resource AI runtimes
+* Members of the broader open source Smalltalk ecosystem
+
+= Speaker Biography
+
+== David Long
+
+David Long is the founder of SageTea Software and XFone Technologies. He has worked on Smalltalk-based enterprise systems, runtime environments, AI tooling, and secure mobile computing platforms for more than two decades. His recent work focuses on edge AI systems, secure communications infrastructure, and the modernization of the SageTea Runtime under the Eclipse Foundation.
+
+== Stéphane Ducasse
+
+Stéphane Ducasse is a leading contributor to the Pharo ecosystem, co-founder of the Pharo Consortium, and a long-time advocate for open source Smalltalk systems. He has authored numerous books and research papers on software engineering, reflective systems, and programming language design, and recently became a committer on the Eclipse SageTea Runtime project.
+
+= Duration
+
+30–45 minutes
+
+= Type
+
+Technical Presentation / Experience Report
+
+= Links
+
+* Eclipse SageTea Runtime Project
+* Pharo Smalltalk
+* ESUG Conference Series


### PR DESCRIPTION
Adds a proposed ESUG 2026 conference talk submission covering the migration and modernization of the Eclipse SageTea Runtime from Squeak to Pharo.